### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -1,4 +1,6 @@
 name: Jest Testing
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/SnareHanger/mikecohen.us/security/code-scanning/1](https://github.com/SnareHanger/mikecohen.us/security/code-scanning/1)

In general, the fix is to explicitly declare the `permissions` for the `GITHUB_TOKEN` in the workflow, either at the top level (applying to all jobs) or within the specific job. For a Jest testing workflow that only needs to read the repository contents, the minimal appropriate permission is `contents: read`. This documents the intent and prevents the workflow from unintentionally having broader write access if defaults are changed or if the workflow is copied elsewhere.

The best fix without changing existing functionality is to add a root-level `permissions` block right after the `name:` line (or before `jobs:`) in `.github/workflows/jest.yml`, setting `contents: read`. This will apply to the `test` job since it does not override permissions. No additional imports, actions, or steps are required; the rest of the workflow remains unchanged.

Concretely:
- Edit `.github/workflows/jest.yml`.
- Insert:

  ```yaml
  permissions:
    contents: read
  ```

  after `name: Jest Testing` (line 1).  
- Do not modify any other lines.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
