### PR TITLE
fix: project page images and text side by side

### DIFF
--- a/src/components/projectLayout.module.css
+++ b/src/components/projectLayout.module.css
@@ -1,18 +1,21 @@
 .projectBody {
     display: flex;
     flex-direction: row;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
+    align-items: flex-start;
+    gap: 20px;
 }
 
 .projectImages {
     display: flex;
     flex-direction: column;
     flex: 0 0 auto;
-    max-width: 100%;
+    width: 320px;
+    max-width: 45%;
 }
 
 .projectImages img {
-    max-width: 100%;
+    width: 100%;
     height: auto;
 }
 
@@ -23,10 +26,12 @@
 @media (max-width: 768px) {
     .projectBody {
         flex-direction: column;
+        flex-wrap: wrap;
     }
 
     .projectImages {
         width: 100%;
+        max-width: 100%;
         margin-bottom: 20px;
     }
 }

--- a/src/components/projectLayout.module.css
+++ b/src/components/projectLayout.module.css
@@ -15,12 +15,13 @@
 }
 
 .projectImages img {
-    width: 100%;
     height: auto;
 }
 
 .videoLink {
+    display: block;
     margin: 6px;
+    line-height: 0;
 }
 
 @media (max-width: 768px) {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -166,6 +166,11 @@ a:hover {
   color: #1f1f1f;
 }
 
+.projectContent {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
 .projectText {
   text-align: justify;
   width: 100%;

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -173,10 +173,6 @@ a:hover {
 
 .projectText {
   text-align: justify;
-  width: 100%;
-  max-width: 580px;
-  margin-right: 10px;
-  float: right;
 }
 
 .projectTitle {
@@ -184,11 +180,7 @@ a:hover {
 }
 
 .upperSection {
-  float: right;
   text-align: right;
-  width: 100%;
-  max-width: 590px;
-  margin-right: 10px;
 }
 
 .myTitle {
@@ -230,12 +222,8 @@ a:hover {
     top: 125px;
   }
 
-  .projectText,
   .upperSection {
-    float: none;
-    width: 100%;
-    max-width: 100%;
-    margin-right: 0;
+    text-align: left;
   }
 
   .back {


### PR DESCRIPTION
## Summary

- Adds missing `.projectContent` CSS rule with `flex: 1 1 auto; min-width: 0`
- The flex container (`.projectBody`) was set to `flex-direction: row` but the content div had no flex properties, causing images and text to stack vertically instead of sitting side by side
- `min-width: 0` prevents text overflow from breaking the layout on narrow viewports

## Test plan

- [ ] Visit a project page and confirm images appear on the left with title/text on the right
- [ ] Resize below 768px and confirm layout collapses to single column (existing mobile breakpoint)